### PR TITLE
Install mediocre and use registry cache

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,7 +62,7 @@ jobs:
       -
         name: Pull sha image # this is genuinely faster than load:true on previous step
         run: |
-          docker build --cache-from ${{ steps.meta-sha.outputs.tags }} .
+          DOCKER_BUILDKIT=1 docker build --cache-from ${{ steps.meta-sha.outputs.tags }} .
 #          docker pull ${{ steps.meta-sha.outputs.tags }} # should only be one tag
       -
         name: Install testing tools

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,9 +59,11 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-#      -
-#        name: Pull sha image # this is genuinely faster than load:true on previous step
-#        run: docker pull ${{ steps.meta-sha.outputs.tags }} # should only be one tag
+      -
+        name: Pull sha image # this is genuinely faster than load:true on previous step
+        run: |
+          docker build --cache-from ${{ steps.meta-sha.outputs.tags }} Dockerfile
+#          docker pull ${{ steps.meta-sha.outputs.tags }} # should only be one tag
       -
         name: Install testing tools
         env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,8 +61,8 @@ jobs:
         # pre-pulling makes subsequent docker steps faster
         # only pre-pull the most relevant image (fallback if not found)
         run: |
-          docker pull ${{ steps.tags.outputs.sha }} & \
-            || docker pull ${{ steps.tags.outputs.main }} & \
+          docker pull ${{ steps.tags.outputs.sha }} \
+            || docker pull ${{ steps.tags.outputs.main }} \
             || docker pull ${{ steps.tags.outputs.master }} &
       -
         name: Check out the repo

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           images: |
             obroomhall/mediocre
+          sep-tags: ",\n"
           tags: |
             type=sha
             type=sha,suffix=-cache
@@ -43,8 +44,10 @@ jobs:
             type=ref,event=pr,suffix=-cache
       -
         name: Docker background pull
+        env:
+          to_pull: ${{ format('{0}{1}{2}', '[', steps.meta.outputs.tags, ']') }}
         run: |
-          docker pull ${{ steps.meta.outputs.tags[0] }}
+          docker pull $to_pull
       -
         name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           images: |
             obroomhall/mediocre
-          sep-tags: '","'
           # be aware of priorities here, since highest priority determines the label org.opencontainers.image.version
           # any tag with an unspecified priority receives a default, see https://github.com/docker/metadata-action#priority-attribute
           # they also determine the order of the output array
@@ -48,13 +47,11 @@ jobs:
       -
         name: Docker meta parse
         id: tags
-        env:
-          TAGS: ${{ format('{0}{1}{2}', '["', steps.meta.outputs.tags, '"]') }}
         run: |
-          echo "main=${{ fromJSON(env.TAGS)[0] }}" >> "$GITHUB_OUTPUT"
-          echo "main-cache=${{ fromJSON(env.TAGS)[1] }}" >> "$GITHUB_OUTPUT"
-          echo "sha=${{ fromJSON(env.TAGS)[2] }}" >> "$GITHUB_OUTPUT"
-          echo "sha-cache=${{ fromJSON(env.TAGS)[4] }}" >> "$GITHUB_OUTPUT"
+          echo "main=${{ fromJSON(steps.meta.outputs.json).tags[0] }}" >> "$GITHUB_OUTPUT"
+          echo "main-cache=${{ fromJSON(steps.meta.outputs.json).tags[1] }}" >> "$GITHUB_OUTPUT"
+          echo "sha=${{ fromJSON(steps.meta.outputs.json).tags[2] }}" >> "$GITHUB_OUTPUT"
+          echo "sha-cache=${{ fromJSON(steps.meta.outputs.json).tags[3] }}" >> "$GITHUB_OUTPUT"
       -
         name: Docker background pull
         run: |
@@ -62,7 +59,7 @@ jobs:
           echo ${{ steps.tags.outputs.main-cache }}
           echo ${{ steps.tags.outputs.sha }}
           echo ${{ steps.tags.outputs.sha-cache }}
-          docker pull $to_pull
+          docker pull $to_pull &
       -
         name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,7 +45,7 @@ jobs:
             type=sha,priority=4
             type=sha,suffix=-cache,priority=3
             type=raw,value=master,priority=2
-            type=sha,value=master,suffix=-cache,priority=1
+            type=raw,value=master,suffix=-cache,priority=1
       -
         name: Docker meta parse
         id: tags

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,10 +60,15 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       -
+        name: Setup docker layer caching
+        uses: satackey/action-docker-layer-caching@v0.0.11
+        # Ignore the failure of a step and avoid terminating the job.
+        continue-on-error: true
+      -
         name: Pull sha image # this is genuinely faster than load:true on previous step
         run: |
-          DOCKER_BUILDKIT=1 docker build --cache-from ${{ steps.meta-sha.outputs.tags }} .
-#          docker pull ${{ steps.meta-sha.outputs.tags }} # should only be one tag
+#          DOCKER_BUILDKIT=1 docker build --cache-from ${{ steps.meta-sha.outputs.tags }} .
+          docker pull ${{ steps.meta-sha.outputs.tags }} # should only be one tag
       -
         name: Install testing tools
         env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,7 @@ jobs:
       -
         name: Docker background pull
         run: |
-          docker pull ${{ steps.tags.outputs.sha }} || docker pull ${{ steps.tags.outputs.main }} || docker pull ${{ steps.tags.outputs.master }} &
+          docker pull ${{ steps.tags.outputs.sha }} || docker pull ${{ steps.tags.outputs.main }} || docker pull ${{ steps.tags.outputs.master }}
       -
         name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,7 @@ jobs:
           cache-to: type=gha,mode=max
       -
         name: Setup docker layer caching
-        uses: satackey/action-docker-layer-caching@v0.0.11
+        uses: jpribyl/action-docker-layer-caching@v0.1.1
         # Ignore the failure of a step and avoid terminating the job.
         continue-on-error: true
       -

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,10 +51,10 @@ jobs:
         env:
           TAGS: ${{ format('{0}{1}{2}', '["', steps.meta.outputs.tags, '"]') }}
         run: |
-          echo "main=${{ fromJSON(env.TAGS))[0] }}" >> "$GITHUB_OUTPUT"
-          echo "main-cache=${{ fromJSON(env.TAGS))[1] }}" >> "$GITHUB_OUTPUT"
-          echo "sha=${{ fromJSON(env.TAGS))[2] }}" >> "$GITHUB_OUTPUT"
-          echo "sha-cache=${{ fromJSON(env.TAGS))[4] }}" >> "$GITHUB_OUTPUT"
+          echo "main=${{ fromJSON(env.TAGS)[0] }}" >> "$GITHUB_OUTPUT"
+          echo "main-cache=${{ fromJSON(env.TAGS)[1] }}" >> "$GITHUB_OUTPUT"
+          echo "sha=${{ fromJSON(env.TAGS)[2] }}" >> "$GITHUB_OUTPUT"
+          echo "sha-cache=${{ fromJSON(env.TAGS)[4] }}" >> "$GITHUB_OUTPUT"
       -
         name: Docker background pull
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,6 +62,8 @@ jobs:
       -
         name: Pull sha image # this is genuinely faster than load:true on previous step
         run: |
+          ls -lh
+          ls -lh ..
           docker build --cache-from ${{ steps.meta-sha.outputs.tags }} Dockerfile
 #          docker pull ${{ steps.meta-sha.outputs.tags }} # should only be one tag
       -

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,8 +61,8 @@ jobs:
         # pre-pulling makes subsequent docker steps faster
         # only pre-pull the most relevant image (fallback if not found)
         run: |
-          docker pull ${{ steps.tags.outputs.sha }} \
-            || docker pull ${{ steps.tags.outputs.main }} \
+          docker pull ${{ steps.tags.outputs.sha }} & \
+            || docker pull ${{ steps.tags.outputs.main }} & \
             || docker pull ${{ steps.tags.outputs.master }} &
       -
         name: Check out the repo

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,8 +58,12 @@ jobs:
           echo "master-cache=${{ fromJSON(steps.meta.outputs.json).tags[5] }}" >> "$GITHUB_OUTPUT"
       -
         name: Docker background pull
+        # pre-pulling makes subsequent docker steps faster
+        # only pre-pull the most relevant image (fallback if not found)
         run: |
-          docker pull ${{ steps.tags.outputs.sha }} || docker pull ${{ steps.tags.outputs.main }} || docker pull ${{ steps.tags.outputs.master }}
+          docker pull ${{ steps.tags.outputs.sha }} \
+            || docker pull ${{ steps.tags.outputs.main }} \
+            || docker pull ${{ steps.tags.outputs.master }} &
       -
         name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,7 +51,7 @@ jobs:
           to_pull: ${{ format('{0}{1}{2}', '["', steps.meta.outputs.tags, '"]') }}
         run: |
           echo $to_pull
-          echo ${{ fromJSON(format('{0}{1}{2}', '["', steps.meta.outputs.tags, '"]')) }}
+          echo ${{ fromJSON(format('{0}{1}{2}', '["', steps.meta.outputs.tags, '"]'))[0] }}
           docker pull $to_pull
       -
         name: Check out the repo

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,11 +60,9 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       -
-        name: Setup docker layer caching
-        uses: jpribyl/action-docker-layer-caching@v0.1.1
-        continue-on-error: true
-      -
-        name: Pull sha image # this is genuinely faster than load:true on previous step
+        # This is genuinely faster than load:true on previous step
+        # I know, I can barely believe it either
+        name: Pull sha image
         run: |
           docker pull ${{ steps.meta-sha.outputs.tags }} # should only be one tag
       -
@@ -110,6 +108,7 @@ jobs:
             type=ref,event=tag
             type=ref,event=pr
       -
+        # This doesn't actually build, since the cache was exported in the other docker/build-push-action step
         name: Re-tag and push image
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,7 +62,6 @@ jobs:
       -
         name: Setup docker layer caching
         uses: jpribyl/action-docker-layer-caching@v0.1.1
-        # Ignore the failure of a step and avoid terminating the job.
         continue-on-error: true
       -
         name: Pull sha image # this is genuinely faster than load:true on previous step

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,7 @@ jobs:
       -
         name: Docker background pull
         run: |
-          docker pull ${{ steps.tags.outputs.sha }} || docker pull ${{ steps.tags.outputs.main }} || ${{ steps.tags.outputs.master }} &
+          docker pull ${{ steps.tags.outputs.sha }} || docker pull ${{ steps.tags.outputs.main }} || docker pull ${{ steps.tags.outputs.master }} &
       -
         name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,7 +51,7 @@ jobs:
           to_pull: ${{ format('{0}{1}{2}', '["', steps.meta.outputs.tags, '"]') }}
         run: |
           echo $to_pull
-          echo ${{ fromJSON($to_pull) }}
+          echo ${{ fromJSON(format('{0}{1}{2}', '["', steps.meta.outputs.tags, '"]')) }}
           docker pull $to_pull
       -
         name: Check out the repo

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           images: |
             obroomhall/mediocre
-          sep-tags: ",\n"
+          sep-tags: '","'
           # be aware of priorities here, since highest priority determines the label org.opencontainers.image.version
           # any tag with an unspecified priority receives a default, see https://github.com/docker/metadata-action#priority-attribute
           # they also determine the order of the output array
@@ -48,9 +48,10 @@ jobs:
       -
         name: Docker background pull
         env:
-          to_pull: ${{ format('{0}{1}{2}', '[', steps.meta.outputs.tags, ']') }}
+          to_pull: ${{ format('{0}{1}{2}', '["', steps.meta.outputs.tags, '"]') }}
         run: |
           echo $to_pull
+          echo ${{ fromJSON($to_pull) }}
           docker pull $to_pull
       -
         name: Check out the repo

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,9 +62,7 @@ jobs:
       -
         name: Pull sha image # this is genuinely faster than load:true on previous step
         run: |
-          ls -lh
-          ls -lh ..
-          docker build --cache-from ${{ steps.meta-sha.outputs.tags }} Dockerfile
+          docker build --cache-from ${{ steps.meta-sha.outputs.tags }} .
 #          docker pull ${{ steps.meta-sha.outputs.tags }} # should only be one tag
       -
         name: Install testing tools

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,14 +36,16 @@ jobs:
           # any tag with an unspecified priority receives a default, see https://github.com/docker/metadata-action#priority-attribute
           # they also determine the order of the output array
           tags: |
-            type=ref,event=branch,priority=4
-            type=ref,event=tag,priority=4
-            type=ref,event=pr,priority=4
-            type=ref,event=branch,suffix=-cache,priority=3
-            type=ref,event=tag,suffix=-cache,priority=3
-            type=ref,event=pr,suffix=-cache,priority=3
-            type=sha,priority=2
-            type=sha,suffix=-cache,priority=1
+            type=ref,event=branch,priority=6
+            type=ref,event=tag,priority=6
+            type=ref,event=pr,priority=6
+            type=ref,event=branch,suffix=-cache,priority=5
+            type=ref,event=tag,suffix=-cache,priority=5
+            type=ref,event=pr,suffix=-cache,priority=5
+            type=sha,priority=4
+            type=sha,suffix=-cache,priority=3
+            type=raw,value=master,priority=2
+            type=sha,value=master,suffix=-cache,priority=1
       -
         name: Docker meta parse
         id: tags
@@ -52,14 +54,12 @@ jobs:
           echo "main-cache=${{ fromJSON(steps.meta.outputs.json).tags[1] }}" >> "$GITHUB_OUTPUT"
           echo "sha=${{ fromJSON(steps.meta.outputs.json).tags[2] }}" >> "$GITHUB_OUTPUT"
           echo "sha-cache=${{ fromJSON(steps.meta.outputs.json).tags[3] }}" >> "$GITHUB_OUTPUT"
+          echo "master=${{ fromJSON(steps.meta.outputs.json).tags[4] }}" >> "$GITHUB_OUTPUT"
+          echo "master-cache=${{ fromJSON(steps.meta.outputs.json).tags[5] }}" >> "$GITHUB_OUTPUT"
       -
         name: Docker background pull
         run: |
-          echo ${{ steps.tags.outputs.main }}
-          echo ${{ steps.tags.outputs.main-cache }}
-          echo ${{ steps.tags.outputs.sha }}
-          echo ${{ steps.tags.outputs.sha-cache }}
-          docker pull $to_pull &
+          docker pull ${{ steps.tags.outputs.sha }} || docker pull ${{ steps.tags.outputs.main }} || ${{ steps.tags.outputs.master }} &
       -
         name: Check out the repo
         uses: actions/checkout@v3
@@ -80,26 +80,26 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          tags: ${{ steps.meta-sha.outputs.tags }}
+          tags: ${{ steps.tags.outputs.sha }}
           labels: ${{ steps.meta-sha.outputs.labels }}
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-      -
-        # This is genuinely faster than load:true on previous step
-        # I know, I can barely believe it either
-        name: Pull sha image
-        run: |
-          docker pull ${{ steps.meta-sha.outputs.tags }} # should only be one tag
+          cache-from: |
+            registry,ref=${{ steps.tags.outputs.sha-cache }}
+            registry,ref=${{ steps.tags.outputs.main-cache }}
+            registry,ref=${{ steps.tags.outputs.master-cache }}
+          cache-to: registry,ref=${{ steps.tags.outputs.sha-cache }}
       -
         name: Install testing tools
         env:
           GRPC_CLIENT_CLI_VERSION: 1.18.0
         run: curl -L -s https://github.com/vadimi/grpc-client-cli/releases/download/v${{ env.GRPC_CLIENT_CLI_VERSION }}/grpc-client-cli_linux_x86_64.tar.gz | tar -C /usr/local/bin -xz
       -
+        name: Pull updated sha image
+        run: docker pull ${{ steps.tags.outputs.sha }}
+      -
         name: Start container
         run: |
-          docker run -d --rm --name mediocre -p 127.0.0.1:80:50051/tcp ${{ steps.meta-sha.outputs.tags }}
+          docker run -d --rm --name mediocre -p 127.0.0.1:80:50051/tcp ${{ steps.tags.outputs.sha }}
           export max_retries=20
           export cur_retries=0
           until [[ $(grpc-client-cli health 127.0.0.1:80 | jq -r '.status') == 'SERVING' ]]; do
@@ -129,8 +129,8 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.tags.outputs.main }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: registry,ref=${{ steps.tags.outputs.sha-cache }}
+          cache-to: registry,ref=${{ steps.tags.outputs.main-cache }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,7 +67,6 @@ jobs:
       -
         name: Pull sha image # this is genuinely faster than load:true on previous step
         run: |
-#          DOCKER_BUILDKIT=1 docker build --cache-from ${{ steps.meta-sha.outputs.tags }} .
           docker pull ${{ steps.meta-sha.outputs.tags }} # should only be one tag
       -
         name: Install testing tools

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,12 +46,22 @@ jobs:
             type=sha,priority=2
             type=sha,suffix=-cache,priority=1
       -
-        name: Docker background pull
+        name: Docker meta parse
+        id: tags
         env:
-          to_pull: ${{ format('{0}{1}{2}', '["', steps.meta.outputs.tags, '"]') }}
+          TAGS: ${{ format('{0}{1}{2}', '["', steps.meta.outputs.tags, '"]') }}
         run: |
-          echo $to_pull
-          echo ${{ fromJSON(format('{0}{1}{2}', '["', steps.meta.outputs.tags, '"]'))[0] }}
+          echo "main=${{ fromJSON(env.TAGS))[0] }}" >> "$GITHUB_OUTPUT"
+          echo "main-cache=${{ fromJSON(env.TAGS))[1] }}" >> "$GITHUB_OUTPUT"
+          echo "sha=${{ fromJSON(env.TAGS))[2] }}" >> "$GITHUB_OUTPUT"
+          echo "sha-cache=${{ fromJSON(env.TAGS))[4] }}" >> "$GITHUB_OUTPUT"
+      -
+        name: Docker background pull
+        run: |
+          echo ${{ steps.tags.outputs.main }}
+          echo ${{ steps.tags.outputs.main-cache }}
+          echo ${{ steps.tags.outputs.sha }}
+          echo ${{ steps.tags.outputs.sha-cache }}
           docker pull $to_pull
       -
         name: Check out the repo

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            obroomhall/mediocre
+          tags: |
+            type=sha
+            type=sha,suffix=-cache
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=ref,event=branch,suffix=-cache
+            type=ref,event=tag,suffix=-cache
+            type=ref,event=pr,suffix=-cache
+      -
+        name: Docker background pull
+        run: |
+          docker pull ${{ steps.meta.outputs.tags[0] }}
+      -
         name: Check out the repo
         uses: actions/checkout@v3
       -
@@ -39,15 +59,6 @@ jobs:
         with:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-      -
-        name: Docker meta sha
-        id: meta-sha
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            obroomhall/mediocre
-          tags: |
-            type=sha
       -
         name: Build and push sha image
         uses: docker/build-push-action@v4
@@ -96,17 +107,6 @@ jobs:
       -
         name: Stop container
         run: docker stop mediocre
-      -
-        name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            obroomhall/mediocre
-          tags: |
-            type=ref,event=branch
-            type=ref,event=tag
-            type=ref,event=pr
       -
         # This doesn't actually build, since the cache was exported in the other docker/build-push-action step
         name: Re-tag and push image

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -84,10 +84,10 @@ jobs:
           labels: ${{ steps.meta-sha.outputs.labels }}
           push: true
           cache-from: |
-            registry,ref=${{ steps.tags.outputs.sha-cache }}
-            registry,ref=${{ steps.tags.outputs.main-cache }}
-            registry,ref=${{ steps.tags.outputs.master-cache }}
-          cache-to: registry,ref=${{ steps.tags.outputs.sha-cache }}
+            type=registry,ref=${{ steps.tags.outputs.sha-cache }}
+            type=registry,ref=${{ steps.tags.outputs.main-cache }}
+            type=registry,ref=${{ steps.tags.outputs.master-cache }}
+          cache-to: type=registry,ref=${{ steps.tags.outputs.sha-cache }}
       -
         name: Install testing tools
         env:
@@ -132,5 +132,5 @@ jobs:
           tags: ${{ steps.tags.outputs.main }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          cache-from: registry,ref=${{ steps.tags.outputs.sha-cache }}
-          cache-to: registry,ref=${{ steps.tags.outputs.main-cache }}
+          cache-from: type=registry,ref=${{ steps.tags.outputs.sha-cache }}
+          cache-to: type=registry,ref=${{ steps.tags.outputs.main-cache }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,20 +33,24 @@ jobs:
           images: |
             obroomhall/mediocre
           sep-tags: ",\n"
+          # be aware of priorities here, since highest priority determines the label org.opencontainers.image.version
+          # any tag with an unspecified priority receives a default, see https://github.com/docker/metadata-action#priority-attribute
+          # they also determine the order of the output array
           tags: |
-            type=sha
-            type=sha,suffix=-cache
-            type=ref,event=branch
-            type=ref,event=tag
-            type=ref,event=pr
-            type=ref,event=branch,suffix=-cache
-            type=ref,event=tag,suffix=-cache
-            type=ref,event=pr,suffix=-cache
+            type=ref,event=branch,priority=4
+            type=ref,event=tag,priority=4
+            type=ref,event=pr,priority=4
+            type=ref,event=branch,suffix=-cache,priority=3
+            type=ref,event=tag,suffix=-cache,priority=3
+            type=ref,event=pr,suffix=-cache,priority=3
+            type=sha,priority=2
+            type=sha,suffix=-cache,priority=1
       -
         name: Docker background pull
         env:
           to_pull: ${{ format('{0}{1}{2}', '[', steps.meta.outputs.tags, ']') }}
         run: |
+          echo $to_pull
           docker pull $to_pull
       -
         name: Check out the repo

--- a/.idea/runConfigurations/Build_and_Run_App.xml
+++ b/.idea/runConfigurations/Build_and_Run_App.xml
@@ -3,7 +3,7 @@
     <deployment type="dockerfile">
       <settings>
         <option name="imageTag" value="mediocre:local" />
-        <option name="buildCliOptions" value="--rm --cache-from mediocre:local" />
+        <option name="buildCliOptions" value="--rm --progress=plain" />
         <option name="buildKitEnabled" value="true" />
         <option name="containerName" value="mediocre" />
         <option name="portBindings">

--- a/.idea/runConfigurations/Build_and_Run_App.xml
+++ b/.idea/runConfigurations/Build_and_Run_App.xml
@@ -2,8 +2,8 @@
   <configuration default="false" name="Build and Run App" type="docker-deploy" factoryName="dockerfile" server-name="Docker">
     <deployment type="dockerfile">
       <settings>
-        <option name="imageTag" value="mediocre:dev-local" />
-        <option name="buildCliOptions" value="--rm --cache-from mediocre:base-dev-local" />
+        <option name="imageTag" value="mediocre:local" />
+        <option name="buildCliOptions" value="--rm --cache-from mediocre:local" />
         <option name="buildKitEnabled" value="true" />
         <option name="containerName" value="mediocre" />
         <option name="portBindings">

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ target_include_directories(mediocre PUBLIC ${Leptonica_INCLUDE_DIRS})
 target_link_libraries(mediocre ${Leptonica_LIBRARIES})
 
 find_package(OpenCV CONFIG REQUIRED)
-message(STATUS "Using OpenCV ${OpenCV_VERSION}")
+message(STATUS "Using OpenCV ${OpenCV_VERSION} with libraries ${OpenCV_LIBS}")
 target_link_libraries(mediocre ${OpenCV_LIBS})
 
 find_package(Protobuf CONFIG REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ add_executable(
         libmediocre/dependency/v1/dependency.cpp
 )
 
+install(TARGETS mediocre)
+
 # include all hpp files
 target_include_directories(mediocre PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN --mount=type=cache,target=/local/opencv/build \
 ENV CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:/local/opencv/install/lib/cmake
 
 # need to point towards opencv shared libraries since cmake strips the rpath at installation, see https://stackoverflow.com/a/22209962/1081679
-# we should be staticly, but see https://github.com/opencv/opencv/issues/21447#issuecomment-1013088996
+# we should be building staticly, but see https://github.com/opencv/opencv/issues/21447#issuecomment-1013088996
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/local/opencv/install/lib/
 
 # install grpc and protobuf

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,9 +127,10 @@ RUN --mount=type=bind,source=libmediocre,target=/local/mediocre/source/libmedioc
     && cmake --build . \
     && make -j 4 \
     && make install
+ENV PATH=$PATH:/local/mediocre/install/bin
 
 # run mediocre
-ENTRYPOINT ["/local/mediocre/install/bin/mediocre"]
+ENTRYPOINT ["mediocre"]
 EXPOSE 50051
 HEALTHCHECK --interval=30s --timeout=3s \
   CMD grpc-client-cli health 127.0.0.1:50051

--- a/libmediocre/main/main.cpp
+++ b/libmediocre/main/main.cpp
@@ -3,6 +3,7 @@
 #include <libmediocre/server/server.hpp>
 
 int main(int argc, char *argv[]) {
-    mediocre::server::run_server(50051);
+    auto server = mediocre::server::Server(50051);
+    server.run_server();
     return EXIT_SUCCESS;
 }

--- a/libmediocre/server/server.hpp
+++ b/libmediocre/server/server.hpp
@@ -2,10 +2,24 @@
 #define mediocre_server_h
 
 #include <cstdint>
+#include <grpcpp/server_builder.h>
+#include <iomanip>
 
 namespace mediocre::server {
 
-    void run_server(uint16_t port);
+    class Server {
+    private:
+        static std::string get_server_address(uint16_t port);
+        static void register_listener(grpc::ServerBuilder &builder, const std::string &server_address);
+        static void register_services(grpc::ServerBuilder &builder);
+        std::string server_address;
+        std::unique_ptr<grpc::Server> server;
+
+    public:
+        explicit Server(uint16_t port);
+        void run_server();
+    };
+
 
 }// namespace mediocre::server
 

--- a/pull-and-retag.ps1
+++ b/pull-and-retag.ps1
@@ -1,15 +1,15 @@
 # Pulls an image from docker hub and re-tags it for local development
 
 $repo = "obroomhall/mediocre"
-$tagToPull = Read-Host -Prompt "Which tag would you like to pull? [dev-master]"
+$tagToPull = Read-Host -Prompt "Which tag would you like to pull? [master]"
 
 if (!$tagToPull) {
-    $tagToPull = "dev-master"
+    $tagToPull = "master"
 }
 
 docker pull ${repo}:${tagToPull}
 
 if ($?) {
-    Write-Host "Retagging ${repo}:${tagToPull} as mediocre:dev-local"
-    docker tag ${repo}:${tagToPull} mediocre:dev-local
+    Write-Host "Retagging ${repo}:${tagToPull} as mediocre:local"
+    docker tag ${repo}:${tagToPull} mediocre:local
 }


### PR DESCRIPTION
Better to install the library than run from the build directory. I did however come across [some caveats](https://github.com/obroomhall/mediocre/pull/12/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R43-R45):
```
# need to point towards opencv shared libraries since cmake strips the rpath at installation, see https://stackoverflow.com/a/22209962/1081679
# we should be building staticly, but see https://github.com/opencv/opencv/issues/21447#issuecomment-1013088996
ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/local/opencv/install/lib/
```