### PR TITLE
Support Local Connections from GRPC Web

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,9 @@
+services:
+  mediocre:
+    image: mediocre:local-release
+    container_name: mediocre
+    pull_policy: build
+    build:
+      dockerfile: ./Dockerfile
+    ports:
+    - 50051:50051

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,3 +7,10 @@ services:
       dockerfile: ./Dockerfile
     ports:
     - 50051:50051
+  mediocre-proxy:
+    image: envoyproxy/envoy:v1.22.0
+    container_name: mediocre-proxy
+    ports:
+      - 50050:50050
+    volumes:
+      - ./envoy.yaml:/etc/envoy/envoy.yaml

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -1,0 +1,61 @@
+static_resources:
+  listeners:
+    - name: listener_0
+      address:
+        socket_address: { address: 0.0.0.0, port_value: 50050 }
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                codec_type: auto
+                stat_prefix: ingress_http
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains: ["*"]
+                      routes:
+                        - match: { prefix: "/" }
+                          route:
+                            cluster: echo_service
+                            timeout: 0s
+                            max_stream_duration:
+                              grpc_timeout_header_max: 0s
+                      cors:
+                        allow_origin_string_match:
+                          - exact: "http://localhost:5173"
+                        allow_methods: POST, OPTIONS
+                        allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                        max_age: "1728000"
+                        expose_headers: grpc-encoding,grpc-status,grpc-message
+                http_filters:
+                  - name: envoy.filters.http.grpc_web
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.cors
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+    - name: echo_service
+      connect_timeout: 0.25s
+      type: logical_dns
+      # HTTP/2 support
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      lb_policy: round_robin
+      load_assignment:
+        cluster_name: cluster_0
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: host.docker.internal
+                      port_value: 50051


### PR DESCRIPTION
Adds an Envoy proxy which allows connections from a grpc-web client.

Currently setup to accept requests from a non-ssl localhost connection, will update to work with remote ssl connections soon.